### PR TITLE
fix redundant image name

### DIFF
--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -46,17 +46,14 @@ jobs:
         if: ${{ startsWith(github.ref, 'refs/heads/main') }}
         run: |
           echo TAG_NAME=latest >> $GITHUB_ENV
-          echo IMG_REPOSITORY_NAME=$( echo ${{ github.repository_owner }} | awk '{print tolower($0)}' ) >> $GITHUB_ENV
       - name: Retrieve tag name (feat branch)
         if: ${{ startsWith(github.ref, 'refs/heads/feat') }}
         run: |
           echo "TAG_NAME=latest-$(echo ${GITHUB_REF#refs/heads/})" >> $GITHUB_ENV
-          echo IMG_REPOSITORY_NAME=$( echo ${{ github.repository_owner }} | awk '{print tolower($0)}' ) >> $GITHUB_ENV
       - name: Retrieve tag name (tag)
         if: ${{ startsWith(github.ref, 'refs/tags/') }}
         run: |
           echo TAG_NAME=$(echo $GITHUB_REF | sed -e "s|refs/tags/||") >> $GITHUB_ENV
-          echo IMG_REPOSITORY_NAME=$( echo ${{ github.repository_owner }} | awk '{print tolower($0)}' ) >> $GITHUB_ENV
       - name: Build and push container image
         if: ${{ inputs.push-image }}
         id: build-image
@@ -67,10 +64,10 @@ jobs:
           platforms: linux/amd64, linux/arm64
           push: true
           tags: |
-            ghcr.io/${{ env.IMG_REPOSITORY_NAME }}/${{ github.repository }}:${{ env.TAG_NAME }}
+            ghcr.io/${{ github.repository }}:${{ env.TAG_NAME }}
       - id: setoutput
         name: Set output parameters
         run: |
-          echo "repository=ghcr.io/${{ env.IMG_REPOSITORY_NAME }}/${{ github.repository }}" >> $GITHUB_OUTPUT
+          echo "repository=ghcr.io/${{ github.repository }}" >> $GITHUB_OUTPUT
           echo "tag=${{ env.TAG_NAME }}" >> $GITHUB_OUTPUT
           echo "digest=${{ steps.build-image.outputs.digest }}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Describe your changes

Images are currently being pushed to `ghcr.io/spinkube/spinkube/runtime-class-manager`. This PR removes the redundant `spinkube`.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- I tested the changes with the following distributions:
  - [ ] Kind
  - [ ] MiniKube
  - [ ] MicroK8s
  - [ ] Rancher RKE2
  - [ ] Azure AKS
  - [ ] GCP GKE (Ubuntu nodes)
  - [ ] AWS EKS (AmazonLinux2 nodes)
  - [ ] AWS EKS (Ubuntu nodes)
  - [ ] Digital Ocean Kubernetes