### PR TITLE
Add shim downloader

### DIFF
--- a/.github/workflows/downloader-build.yml
+++ b/.github/workflows/downloader-build.yml
@@ -1,0 +1,44 @@
+name: Build installer image, sign it, and generate SBOMs
+
+on:
+  workflow_call:
+    outputs:
+      digest:
+        description: "Container image digest"
+        value: ${{jobs.build.outputs.digest}}
+
+  push:
+    branches:
+      - "main"
+      - "feat-**"
+
+jobs:
+  build:
+    uses: ./.github/workflows/container-image.yml
+    permissions:
+      contents: read
+      packages: write
+    with:
+      image-name: shim-downloader
+      dockerfile: ./images/downloader/Dockerfile
+      push-image: true
+
+  sign:
+    needs: build
+    uses: ./.github/workflows/sign-image.yml
+    permissions:
+      packages: write
+      id-token: write
+    with:
+      image-repository: ${{ needs.build.outputs.repository }}
+      image-digest: ${{ needs.build.outputs.digest }}
+
+  sbom:
+    needs: build
+    uses: ./.github/workflows/sbom.yml
+    permissions:
+      packages: write
+      id-token: write
+    with:
+      image-name: node-installer
+      image-digest: ${{ needs.build.outputs.digest }}

--- a/images/downloader/Dockerfile
+++ b/images/downloader/Dockerfile
@@ -1,0 +1,5 @@
+FROM alpine:3.19.1
+
+RUN apk add curl bash
+COPY download_shim.sh /download_shim.sh
+CMD bash /download_shim.sh

--- a/images/downloader/download_shim.sh
+++ b/images/downloader/download_shim.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+declare -A levels=([DEBUG]=0 [INFO]=1 [WARN]=2 [ERROR]=3)
+script_logging_level="INFO"
+
+log() {
+    local log_message=$1
+    local log_priority=$2
+
+    #check if level exists
+    [[ ${levels[$log_priority]} ]] || return 1
+
+    #check if level is enough
+    (( ${levels[$log_priority]} < ${levels[$script_logging_level]} )) && return 2
+
+    #log here
+    d=$(date '+%Y-%m-%dT%H:%M:%S')
+    echo -e "${d}\t${log_priority}\t${log_message}"
+}
+
+log "start downloading shim from  ${SHIM_LOCATION}..." "INFO"
+
+mkdir -p /assets
+
+curl -sL "${SHIM_LOCATION}"  | tar -xzf - -C /assets
+log "download successful:" "INFO"
+
+ls -lah /assets

--- a/internal/controller/shim_controller.go
+++ b/internal/controller/shim_controller.go
@@ -313,6 +313,36 @@ func (sr *ShimReconciler) createJobManifest(shim *kwasmv1.Shim, node *corev1.Nod
 	name := node.Name + "-" + shim.Name + "-" + operation
 	nameMax := int(math.Min(float64(len(name)), 63))
 
+	initContainer := []corev1.Container{{}}
+	args := []string{"uninstall"}
+
+	if operation == INSTALL {
+		initContainer = []corev1.Container{{
+			Image: "ghcr.io/spinkube/shim-downloader:latest",
+			Name:  "downloader",
+			SecurityContext: &corev1.SecurityContext{
+				Privileged: &priv,
+			},
+			Env: []corev1.EnvVar{
+				{
+					Name:  "SHIM_LOCATION",
+					Value: shim.Spec.FetchStrategy.AnonHTTP.Location,
+				},
+			},
+			VolumeMounts: []corev1.VolumeMount{
+				{
+					Name:      "shim-download",
+					MountPath: "/assets",
+				},
+			},
+		}}
+		args = []string{
+			"install",
+			"-H",
+			"/mnt/node-root",
+		}
+	}
+
 	job := &batchv1.Job{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Job",
@@ -338,36 +368,31 @@ func (sr *ShimReconciler) createJobManifest(shim *kwasmv1.Shim, node *corev1.Nod
 				Spec: corev1.PodSpec{
 					NodeName: node.Name,
 					HostPID:  true,
-					Volumes: []corev1.Volume{{
-						Name: "root-mount",
-						VolumeSource: corev1.VolumeSource{
-							HostPath: &corev1.HostPathVolumeSource{
-								Path: "/",
+					Volumes: []corev1.Volume{
+						{
+							Name: "shim-download",
+						},
+						{
+							Name: "root-mount",
+							VolumeSource: corev1.VolumeSource{
+								HostPath: &corev1.HostPathVolumeSource{
+									Path: "/",
+								},
 							},
 						},
-					}},
+					},
+					InitContainers: initContainer,
 					Containers: []corev1.Container{{
-						Image: "voigt/kwasm-node-installer:" + operation,
+						Image: "ghcr.io/spinkube/node-installer:latest",
+						Args:  args,
 						Name:  "provisioner",
 						SecurityContext: &corev1.SecurityContext{
 							Privileged: &priv,
 						},
 						Env: []corev1.EnvVar{
 							{
-								Name:  "NODE_ROOT",
+								Name:  "HOST_ROOT",
 								Value: "/mnt/node-root",
-							},
-							{
-								Name:  "SHIM_LOCATION",
-								Value: shim.Spec.FetchStrategy.AnonHTTP.Location,
-							},
-							{
-								Name:  "RUNTIMECLASS_NAME",
-								Value: shim.Spec.RuntimeClass.Name,
-							},
-							{
-								Name:  "RUNTIMECLASS_HANDLER",
-								Value: shim.Spec.RuntimeClass.Handler,
 							},
 							{
 								Name:  "SHIM_FETCH_STRATEGY",
@@ -378,6 +403,10 @@ func (sr *ShimReconciler) createJobManifest(shim *kwasmv1.Shim, node *corev1.Nod
 							{
 								Name:      "root-mount",
 								MountPath: "/mnt/node-root",
+							},
+							{
+								Name:      "shim-download",
+								MountPath: "/assets",
 							},
 						},
 					}},


### PR DESCRIPTION
## Describe your changes

This PR makes sure we use the node-installer for the install job.
The PR furthermore adds a "shim-downloader" image, to make shim downloading configurable.

Addresses #52

## Issue ticket number and link

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- I tested the changes with the following distributions:
  - [ ] Kind
  - [ ] MiniKube
  - [ ] MicroK8s
  - [ ] Rancher RKE2
  - [ ] Azure AKS
  - [ ] GCP GKE (Ubuntu nodes)
  - [ ] AWS EKS (AmazonLinux2 nodes)
  - [ ] AWS EKS (Ubuntu nodes)
  - [ ] Digital Ocean Kubernetes