### PR TITLE
feat: implement install and uninstall flow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,12 @@ updates:
       interval: "weekly"
     labels:
       - "area/dependencies"
+  - package-ecosystem: docker
+    directory: "/images/downloader"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "area/dependencies"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/workflows/downloader-build.yml
+++ b/.github/workflows/downloader-build.yml
@@ -21,6 +21,7 @@ jobs:
     with:
       image-name: shim-downloader
       dockerfile: ./images/downloader/Dockerfile
+      docker-context: ./images/downloader
       push-image: true
 
   sign:

--- a/.github/workflows/downloader-build.yml
+++ b/.github/workflows/downloader-build.yml
@@ -1,0 +1,44 @@
+name: Build installer image, sign it, and generate SBOMs
+
+on:
+  workflow_call:
+    outputs:
+      digest:
+        description: "Container image digest"
+        value: ${{jobs.build.outputs.digest}}
+
+  push:
+    branches:
+      - "main"
+      - "feat-**"
+
+jobs:
+  build:
+    uses: ./.github/workflows/container-image.yml
+    permissions:
+      contents: read
+      packages: write
+    with:
+      image-name: shim-downloader
+      dockerfile: ./images/downloader/Dockerfile
+      push-image: true
+
+  sign:
+    needs: build
+    uses: ./.github/workflows/sign-image.yml
+    permissions:
+      packages: write
+      id-token: write
+    with:
+      image-repository: ${{ needs.build.outputs.repository }}
+      image-digest: ${{ needs.build.outputs.digest }}
+
+  sbom:
+    needs: build
+    uses: ./.github/workflows/sbom.yml
+    permissions:
+      packages: write
+      id-token: write
+    with:
+      image-name: node-installer
+      image-digest: ${{ needs.build.outputs.digest }}

--- a/.github/workflows/downloader-build.yml
+++ b/.github/workflows/downloader-build.yml
@@ -1,4 +1,4 @@
-name: Build installer image, sign it, and generate SBOMs
+name: Build shim-downloader image, sign it, and generate SBOMs
 
 on:
   workflow_call:
@@ -41,5 +41,5 @@ jobs:
       packages: write
       id-token: write
     with:
-      image-name: node-installer
+      image-name: shim-downloader
       image-digest: ${{ needs.build.outputs.digest }}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,7 @@
             "type": "go",
             "request": "launch",
             "mode": "auto",
-            "program": "./cmd/main.go"
+            "program": "./cmd/rcm/main.go"
         }
     ]
 }

--- a/cmd/node-installer/uninstall.go
+++ b/cmd/node-installer/uninstall.go
@@ -39,8 +39,10 @@ var uninstallCmd = &cobra.Command{
 		restarter := containerd.NewRestarter()
 
 		if err := RunUninstall(config, rootFs, hostFs, restarter); err != nil {
-			slog.Error("failed to uninstall", "error", err)
-			os.Exit(1)
+			slog.Error("failed to uninstall shim", "error", err)
+
+			// Exiting with 0 to prevent Kubernetes Jobs from running repetitively
+			os.Exit(0)
 		}
 	},
 }
@@ -50,7 +52,7 @@ func init() {
 }
 
 func RunUninstall(config Config, rootFs, hostFs afero.Fs, restarter containerd.Restarter) error {
-	slog.Info("uninstall called")
+	slog.Info("uninstall called", "shim", config.Runtime.Name)
 	shimName := config.Runtime.Name
 	runtimeName := path.Join(config.Kwasm.Path, "bin", shimName)
 

--- a/cmd/node-installer/uninstall.go
+++ b/cmd/node-installer/uninstall.go
@@ -64,7 +64,7 @@ func RunUninstall(config Config, rootFs, hostFs afero.Fs, restarter containerd.R
 
 	configChanged, err := containerdConfig.RemoveRuntime(binPath)
 	if err != nil {
-		return fmt.Errorf("failed to write conteainerd config for shim '%s': %w", runtimeName, err)
+		return fmt.Errorf("failed to write containerd config for shim '%s': %w", runtimeName, err)
 	}
 
 	if !configChanged {

--- a/config/samples/test_shim_spin.yaml
+++ b/config/samples/test_shim_spin.yaml
@@ -1,10 +1,10 @@
 apiVersion: runtime.kwasm.sh/v1alpha1 
 kind: Shim
 metadata:
-  name: wasmtime-spin-v2
+  name: spin-v2
   labels:
-    app.kubernetes.io/name: wasmtime-spin-v2
-    app.kubernetes.io/instance: wasmtime-spin-v2
+    app.kubernetes.io/name: spin-v2
+    app.kubernetes.io/instance: spin-v2
     app.kubernetes.io/part-of: kwasm-operator
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/created-by: kwasm-operator
@@ -15,10 +15,10 @@ spec:
   fetchStrategy:
     type: annonymousHttp
     anonHttp:
-      location: "https://github.com/deislabs/containerd-wasm-shims/releases/download/v0.10.0/containerd-wasm-shims-v2-spin-linux-aarch64.tar.gz"
+      location: "https://github.com/spinkube/containerd-shim-spin/releases/download/v0.14.1/containerd-shim-spin-v2-linux-aarch64.tar.gz"
 
   runtimeClass:
-    name: wasmtime-spin-v2
+    name: spin-v2
     handler: spin
 
   rolloutStrategy:

--- a/images/downloader/Dockerfile
+++ b/images/downloader/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:3.19.1
 
-RUN apk add curl bash
+RUN apk add --no-cache curl bash tar
 COPY download_shim.sh /download_shim.sh
 CMD bash /download_shim.sh

--- a/images/downloader/Dockerfile
+++ b/images/downloader/Dockerfile
@@ -1,0 +1,5 @@
+FROM alpine:3.19.1
+
+RUN apk add curl bash
+COPY download_shim.sh /download_shim.sh
+CMD bash /download_shim.sh

--- a/images/downloader/download_shim.sh
+++ b/images/downloader/download_shim.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+declare -A levels=([DEBUG]=0 [INFO]=1 [WARN]=2 [ERROR]=3)
+script_logging_level="INFO"
+
+log() {
+    local log_message=$1
+    local log_priority=$2
+
+    #check if level exists
+    [[ ${levels[$log_priority]} ]] || return 1
+
+    #check if level is enough
+    (( ${levels[$log_priority]} < ${levels[$script_logging_level]} )) && return 2
+
+    #log here
+    d=$(date '+%Y-%m-%dT%H:%M:%S')
+    echo -e "${d}\t${log_priority}\t${log_message}"
+}
+
+log "start downloading shim from  ${SHIM_LOCATION}..." "INFO"
+
+mkdir -p /assets
+
+curl -sL "${SHIM_LOCATION}"  | tar -xzf - -C /assets
+log "download successful:" "INFO"
+
+ls -lah /assets

--- a/images/downloader/download_shim.sh
+++ b/images/downloader/download_shim.sh
@@ -23,7 +23,9 @@ log "start downloading shim from  ${SHIM_LOCATION}..." "INFO"
 
 mkdir -p /assets
 
-curl -sL "${SHIM_LOCATION}"  | tar -xzf - -C /assets
+# overwrite default name of shim binary; use the name of shim resource instead
+# to enable installing multiple versions of the same shim
+curl -sL "${SHIM_LOCATION}"  | tar --transform "s/containerd-shim-.*/containerd-shim-${SHIM_NAME}/" -xzf - -C /assets
 log "download successful:" "INFO"
 
 ls -lah /assets

--- a/internal/controller/shim_controller.go
+++ b/internal/controller/shim_controller.go
@@ -472,6 +472,10 @@ func (sr *ShimReconciler) createRuntimeClassManifest(shim *rcmv1.Shim) (*nodev1.
 	}
 
 	runtimeClass := &nodev1.RuntimeClass{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "node.k8s.io/v1",
+			Kind:       "RuntimeClass",
+		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   name[:nameMax],
 			Labels: map[string]string{name[:nameMax]: "true"},

--- a/internal/shim/uninstall.go
+++ b/internal/shim/uninstall.go
@@ -2,6 +2,7 @@ package shim
 
 import (
 	"errors"
+	"fmt"
 	"log/slog"
 	"os"
 
@@ -16,16 +17,15 @@ func (c *Config) Uninstall(shimName string) (string, error) {
 	s, ok := st.Shims[shimName]
 	if !ok {
 		slog.Error("shim not installed", "shim", shimName)
-		return "", err
+		return "", fmt.Errorf("shim %s not installed", shimName)
 	}
 	filePath := s.Path
 
 	err = c.hostFs.Remove(filePath)
 	if err != nil {
 		if !errors.Is(err, os.ErrNotExist) {
-			return "", err
+			return "", fmt.Errorf("shim binary did not exist, nothing to delete")
 		}
-		slog.Error("shim binary did not exist, nothing to delete")
 	}
 	st.RemoveShim(shimName)
 	if err = st.Write(); err != nil {

--- a/internal/shim/uninstall.go
+++ b/internal/shim/uninstall.go
@@ -15,8 +15,8 @@ func (c *Config) Uninstall(shimName string) (string, error) {
 	}
 	s, ok := st.Shims[shimName]
 	if !ok {
-		slog.Warn("shim not installed", "shim", shimName)
-		return "", nil
+		slog.Error("shim not installed", "shim", shimName)
+		return "", err
 	}
 	filePath := s.Path
 
@@ -25,7 +25,7 @@ func (c *Config) Uninstall(shimName string) (string, error) {
 		if !errors.Is(err, os.ErrNotExist) {
 			return "", err
 		}
-		slog.Warn("shim binary did not exist, nothing to delete")
+		slog.Error("shim binary did not exist, nothing to delete")
 	}
 	st.RemoveShim(shimName)
 	if err = st.Write(); err != nil {

--- a/internal/shim/uninstall.go
+++ b/internal/shim/uninstall.go
@@ -17,6 +17,7 @@ func (c *Config) Uninstall(shimName string) (string, error) {
 	s, ok := st.Shims[shimName]
 	if !ok {
 		slog.Error("shim not installed", "shim", shimName)
+		os.Exit(0)
 		return "", fmt.Errorf("shim %s not installed", shimName)
 	}
 	filePath := s.Path
@@ -24,6 +25,8 @@ func (c *Config) Uninstall(shimName string) (string, error) {
 	err = c.hostFs.Remove(filePath)
 	if err != nil {
 		if !errors.Is(err, os.ErrNotExist) {
+			slog.Error("shim binary did not exist, nothing to delete")
+			os.Exit(0)
 			return "", fmt.Errorf("shim binary did not exist, nothing to delete")
 		}
 	}

--- a/internal/shim/uninstall.go
+++ b/internal/shim/uninstall.go
@@ -3,7 +3,6 @@ package shim
 import (
 	"errors"
 	"fmt"
-	"log/slog"
 	"os"
 
 	"github.com/spinkube/runtime-class-manager/internal/state"
@@ -16,8 +15,6 @@ func (c *Config) Uninstall(shimName string) (string, error) {
 	}
 	s, ok := st.Shims[shimName]
 	if !ok {
-		slog.Error("shim not installed", "shim", shimName)
-		os.Exit(0)
 		return "", fmt.Errorf("shim %s not installed", shimName)
 	}
 	filePath := s.Path
@@ -25,9 +22,7 @@ func (c *Config) Uninstall(shimName string) (string, error) {
 	err = c.hostFs.Remove(filePath)
 	if err != nil {
 		if !errors.Is(err, os.ErrNotExist) {
-			slog.Error("shim binary did not exist, nothing to delete")
-			os.Exit(0)
-			return "", fmt.Errorf("shim binary did not exist, nothing to delete")
+			return "", fmt.Errorf("shim binary at %s does not exist, nothing to delete", filePath)
 		}
 	}
 	st.RemoveShim(shimName)

--- a/internal/shim/uninstall_test.go
+++ b/internal/shim/uninstall_test.go
@@ -38,16 +38,16 @@ func TestConfig_Uninstall(t *testing.T) {
 		want    string
 		wantErr bool
 	}{
-		// {
-		// 	"shim not installed",
-		// 	fields{
-		// 		tests.FixtureFs("../../testdata/node-installer/shim"),
-		// 		"/opt/kwasm",
-		// 	},
-		// 	args{"not-existing-shim"},
-		// 	"",
-		// 	false,
-		// },
+		{
+			"shim not installed",
+			fields{
+				tests.FixtureFs("../../testdata/node-installer/shim"),
+				"/opt/kwasm",
+			},
+			args{"not-existing-shim"},
+			"",
+			true,
+		},
 		{
 			"missing shim binary",
 			fields{

--- a/internal/shim/uninstall_test.go
+++ b/internal/shim/uninstall_test.go
@@ -48,16 +48,16 @@ func TestConfig_Uninstall(t *testing.T) {
 		// 	"",
 		// 	false,
 		// },
-		// {
-		// 	"missing shim binary",
-		// 	fields{
-		// 		tests.FixtureFs("../../testdata/node-installer/shim-missing-binary"),
-		// 		"/opt/kwasm",
-		// 	},
-		// 	args{"spin-v1"},
-		// 	"/opt/kwasm/bin/containerd-shim-spin-v1",
-		// 	false,
-		// },
+		{
+			"missing shim binary",
+			fields{
+				tests.FixtureFs("../../testdata/node-installer/shim-missing-binary"),
+				"/opt/kwasm",
+			},
+			args{"spin-v1"},
+			"/opt/kwasm/bin/containerd-shim-spin-v1",
+			false,
+		},
 		{
 			"successful shim uninstallation",
 			fields{

--- a/internal/shim/uninstall_test.go
+++ b/internal/shim/uninstall_test.go
@@ -38,26 +38,26 @@ func TestConfig_Uninstall(t *testing.T) {
 		want    string
 		wantErr bool
 	}{
-		{
-			"shim not installed",
-			fields{
-				tests.FixtureFs("../../testdata/node-installer/shim"),
-				"/opt/kwasm",
-			},
-			args{"not-existing-shim"},
-			"",
-			false,
-		},
-		{
-			"missing shim binary",
-			fields{
-				tests.FixtureFs("../../testdata/node-installer/shim-missing-binary"),
-				"/opt/kwasm",
-			},
-			args{"spin-v1"},
-			"/opt/kwasm/bin/containerd-shim-spin-v1",
-			false,
-		},
+		// {
+		// 	"shim not installed",
+		// 	fields{
+		// 		tests.FixtureFs("../../testdata/node-installer/shim"),
+		// 		"/opt/kwasm",
+		// 	},
+		// 	args{"not-existing-shim"},
+		// 	"",
+		// 	false,
+		// },
+		// {
+		// 	"missing shim binary",
+		// 	fields{
+		// 		tests.FixtureFs("../../testdata/node-installer/shim-missing-binary"),
+		// 		"/opt/kwasm",
+		// 	},
+		// 	args{"spin-v1"},
+		// 	"/opt/kwasm/bin/containerd-shim-spin-v1",
+		// 	false,
+		// },
 		{
 			"successful shim uninstallation",
 			fields{


### PR DESCRIPTION
## Describe your changes

1. This PR makes sure we use the node-installer for the install job.
2. The PR adds a "shim-downloader" image. The idea is to use the downloader as initContainer: this makes the download & unzip procedure customizable to make shim downloading configurable.
3. This PR adds the configuration required to distinguish "install" and "uninstall" jobs

## Issue ticket number and link

Addresses #52

## How to test

```bash
# create kind cluster with annotations
make kind

# run rcm locally, against kind cluster
CONTROLLER_NAMESPACE="default" \
SHIM_DOWNLOADER_IMAGE="ghcr.io/spinkube/shim-downloader:latest-feat-add_shim_downloader" \
SHIM_NODE_INSTALLER_IMAGE="ghcr.io/spinkube/node-installer:latest-feat-add_shim_downloader" \
go run -ldflags "${LDFLAGS}" ./cmd/rcm/main.go
```

### Install Spin Shim

```bash
# create spin shim resource
kubectl apply -f ./config/samples/test_shim_spin.yaml
```

Two jobs will be scheduled on nodes with label `spin=true`
* `kwasm-worker-spin-v2-install`
* `kwasm-worker2-spin-v2-install`

After jobs will eventually succeed:

```bash
kubectl get shims
NAME      RUNTIMECLASS   READY   NODES
spin-v2   spin-v2        2       2
```

Check containerd config on worker and worker2:

<details>
<summary><code>bash docker exec -it $(docker ps --format json | jq -r '. | "\(.ID) \(.Names)"' | grep kwasm-worker2 | awk '{print $1}') cat /etc/containerd/config.toml</code></summary

```
[...]

# KWASM runtime config for spin-v2
[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.spin-v2]
runtime_type = "/opt/kwasm/bin/containerd-shim-spin-v2"
```
</details>

Check spin-v2 runtime binary:

```bash
docker exec -it $(docker ps --format json | jq -r '. | "\(.ID) \(.Names)"' | grep kwasm-worker2 | awk '{print $1}') ls -lah /opt/kwasm/bin
total 40M
drwxr-xr-x 1 root root  46 May 19 20:35 .
drwxr-xr-x 1 root root  36 May 19 20:35 ..
-rwxr-xr-x 1 root root 40M May 19 20:36 containerd-shim-spin-v2

```

### Uninstall Spin Shim

```bash
# delete spin shim resource
kubectl delete shim spin-v2
```

Two jobs will be scheduled on nodes with label `spin=true`

* `kwasm-worker2-spin-v2-uninstall`
* `kwasm-worker-spin-v2-uninstall`

Check containerd config of worker or worker2; directive for spin-v2 is successfully removed:
`bash docker exec -it $(docker ps --format json | jq -r '. | "\(.ID) \(.Names)"' | grep kwasm-worker2 | awk '{print $1}') cat /etc/containerd/config.toml`

Check for binary, which is also removed:

```bash
docker exec -it $(docker ps --format json | jq -r '. | "\(.ID) \(.Names)"' | grep kwasm-worker2 | awk '{print $1}') ls -lah /opt/kwasm/bin
total 0
drwxr-xr-x 1 root root  0 May 19 20:36 .
drwxr-xr-x 1 root root 36 May 19 20:35 ..
```

## Known Issues

Install and uninstall Jobs spawn two pods in total: one pod successfully doing install/uninstall operations, but ending in unknown state. The other one in "completed" state, doing effectively nothing. This is not as clean as I want it to be.

Bug is documented here: https://github.com/spinkube/runtime-class-manager/issues/140

A fix of this bug should be done in a separate PR.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] ~~If it is a core feature, I have added thorough tests.~~ installation/uninstallation procedure should be tested in a dedicated CI job; right now a helm chart is missing
- I tested the changes with the following distributions:
  - [x] Kind (with rcm running locally)