### PR TITLE
Various fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
   push:
     branches:
-      - 'main'
+      - "main"
   pull_request:
 
 # Declare default permissions as read only.
@@ -38,5 +38,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@3cfe3a4abbb849e10058ce4af15d205b6da42804 # v4.0.0
         with:
-          version: v1.56.2
+          version: v1.57.2
           skip-cache: true

--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ test: manifests generate fmt vet envtest ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test ./... -coverprofile cover.out
 
 GOLANGCI_LINT = $(shell pwd)/bin/golangci-lint
-GOLANGCI_LINT_VERSION ?= v1.54.2
+GOLANGCI_LINT_VERSION ?= v1.57.2
 golangci-lint:
 	@[ -f $(GOLANGCI_LINT) ] || { \
 	set -e ;\

--- a/api/v1alpha1/shim_types.go
+++ b/api/v1alpha1/shim_types.go
@@ -42,9 +42,17 @@ type RuntimeClassSpec struct {
 	Handler string `json:"handler"`
 }
 
+// +kubebuilder:validation:Enum=rolling;recreate
+type RolloutStrategyType string
+
+const (
+	RolloutStrategyTypeRolling  RolloutStrategyType = "rolling"
+	RolloutStrategyTypeRecreate RolloutStrategyType = "recreate"
+)
+
 type RolloutStrategy struct {
-	Type    string      `json:"type"`
-	Rolling RollingSpec `json:"rolling,omitempty"`
+	Type    RolloutStrategyType `json:"type"`
+	Rolling RollingSpec         `json:"rolling,omitempty"`
 }
 
 type RollingSpec struct {

--- a/config/crd/bases/runtime.kwasm.sh_shims.yaml
+++ b/config/crd/bases/runtime.kwasm.sh_shims.yaml
@@ -73,6 +73,9 @@ spec:
                     - maxUpdate
                     type: object
                   type:
+                    enum:
+                    - rolling
+                    - recreate
                     type: string
                 required:
                 - type

--- a/internal/controller/shim_controller.go
+++ b/internal/controller/shim_controller.go
@@ -320,10 +320,6 @@ func (sr *ShimReconciler) createJobManifest(shim *rcmv1.Shim, node *corev1.Node,
 	nameMax := int(math.Min(float64(len(name)), 63))
 
 	job := &batchv1.Job{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "Job",
-			APIVersion: "batch/v1",
-		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name[:nameMax],
 			Namespace: os.Getenv("CONTROLLER_NAMESPACE"),
@@ -439,14 +435,9 @@ func (sr *ShimReconciler) createRuntimeClassManifest(shim *rcmv1.Shim) (*nodev1.
 	}
 
 	runtimeClass := &nodev1.RuntimeClass{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "RuntimeClass",
-			APIVersion: "node.k8s.io/v1",
-		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name[:nameMax],
-			Namespace: os.Getenv("CONTROLLER_NAMESPACE"),
-			Labels:    map[string]string{name[:nameMax]: "true"},
+			Name:   name[:nameMax],
+			Labels: map[string]string{name[:nameMax]: "true"},
 		},
 		Handler: shim.Spec.RuntimeClass.Handler,
 		Scheduling: &nodev1.Scheduling{
@@ -482,12 +473,12 @@ func (sr *ShimReconciler) handleDeleteShim(ctx context.Context, shim *rcmv1.Shim
 func (sr *ShimReconciler) getNodeListFromShimsNodeSelctor(ctx context.Context, shim *rcmv1.Shim) (*corev1.NodeList, error) {
 	nodes := &corev1.NodeList{}
 	if shim.Spec.NodeSelector != nil {
-		err := sr.List(ctx, nodes, client.InNamespace(shim.Namespace), client.MatchingLabels(shim.Spec.NodeSelector))
+		err := sr.List(ctx, nodes, client.MatchingLabels(shim.Spec.NodeSelector))
 		if err != nil {
 			return &corev1.NodeList{}, fmt.Errorf("failed to get node list: %w", err)
 		}
 	} else {
-		err := sr.List(ctx, nodes, client.InNamespace(shim.Namespace))
+		err := sr.List(ctx, nodes)
 		if err != nil {
 			return &corev1.NodeList{}, fmt.Errorf("failed to get node list: %w", err)
 		}


### PR DESCRIPTION
This is a follow up from https://github.com/spinkube/runtime-class-manager/pull/46, it addresses the comments left inside of the review.

Please forgive me for having created a unique PR, if you want I can split each commit into separate PRs.

These are the changes done:

- chore(deps): update golangci-lint
- refactor: replace occurrences of KWasm
- fix: attempt to install shim on all nodes
- refactor: remove unneeded code
- refactor: define rollout strategy type and use constants
- fix: not all rollout strategies are implemented yet
