### PR TITLE
fix(shim_controller.go): set runtimeclass name correctly

### DIFF
--- a/internal/controller/shim_controller.go
+++ b/internal/controller/shim_controller.go
@@ -497,7 +497,7 @@ func (sr *ShimReconciler) handleDeployRuntimeClass(ctx context.Context, shim *rc
 
 // createRuntimeClassManifest creates a RuntimeClass manifest for a Shim.
 func (sr *ShimReconciler) createRuntimeClassManifest(shim *rcmv1.Shim) (*nodev1.RuntimeClass, error) {
-	name := shim.Name
+	name := shim.Spec.RuntimeClass.Name
 	nameMax := int(math.Min(float64(len(name)), 63))
 
 	nodeSelector := shim.Spec.NodeSelector


### PR DESCRIPTION
## Describe your changes
Fixes setting the runtimeclass name.  Previously the shim name was used.  This now updates to use the runtimeclass name specified in the corresponding section of the Shim resource.

## Issue ticket number and link
N/A

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- I tested the changes with the following distributions:
  - [x] Kind
  - [ ] MiniKube
  - [ ] MicroK8s
  - [ ] Rancher RKE2
  - [ ] Azure AKS
  - [ ] GCP GKE (Ubuntu nodes)
  - [ ] AWS EKS (AmazonLinux2 nodes)
  - [ ] AWS EKS (Ubuntu nodes)
  - [ ] Digital Ocean Kubernetes