### PR TITLE
fix(rbac): change job api group to batch

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -5,7 +5,7 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
-  - runtime.kwasm.sh
+  - batch
   resources:
   - jobs
   verbs:
@@ -17,13 +17,13 @@ rules:
   - update
   - watch
 - apiGroups:
-  - runtime.kwasm.sh
+  - batch
   resources:
   - jobs/finalizers
   verbs:
   - update
 - apiGroups:
-  - runtime.kwasm.sh
+  - batch
   resources:
   - jobs/status
   verbs:

--- a/internal/controller/job_controller.go
+++ b/internal/controller/job_controller.go
@@ -36,9 +36,9 @@ type JobReconciler struct {
 	Scheme *runtime.Scheme
 }
 
-//+kubebuilder:rbac:groups=runtime.kwasm.sh,resources=jobs,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=runtime.kwasm.sh,resources=jobs/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=runtime.kwasm.sh,resources=jobs/finalizers,verbs=update
+//+kubebuilder:rbac:groups=batch,resources=jobs,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=batch,resources=jobs/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=batch,resources=jobs/finalizers,verbs=update
 
 // SetupWithManager sets up the controller with the Manager.
 func (jr *JobReconciler) SetupWithManager(mgr ctrl.Manager) error {


### PR DESCRIPTION
## Describe your changes

- Updates the job api group to batch for correct RBAC

Note: I'm not yet able to fully test via the `make build deploy` flow as RBAC issues remain.  Next up are node permissions, which will require a rewrite of node_controller.go.  

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- I tested the changes with the following distributions:
  - [ ] Kind
  - [ ] MiniKube
  - [ ] MicroK8s
  - [ ] Rancher RKE2
  - [ ] Azure AKS
  - [ ] GCP GKE (Ubuntu nodes)
  - [ ] AWS EKS (AmazonLinux2 nodes)
  - [ ] AWS EKS (Ubuntu nodes)
  - [ ] Digital Ocean Kubernetes