### PR TITLE
ref(*): s/kwasm-operator/runtime-class-manager

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ The following settings can be configured:
 Example:
 
 ```yaml
-registry: ghcr.io/your-gh-username/kwasm-operator
+registry: ghcr.io/your-gh-username/runtime-class-manager
 ```
 
 ### Running the controller

--- a/PROJECT
+++ b/PROJECT
@@ -5,7 +5,7 @@
 domain: kwasm.sh
 layout:
 - go.kubebuilder.io/v4
-projectName: kwasm-operator
+projectName: runtime-class-manager
 repo: github.com/spinkube/runtime-class-manager
 resources:
 - api:

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -1,12 +1,12 @@
 # Adds namespace to all resources.
-namespace: kwasm-operator-system
+namespace: runtime-class-manager-system
 
 # Value of this field is prepended to the
 # names of all resources, e.g. a deployment named
 # "wordpress" becomes "alices-wordpress".
 # Note that it should also match with the prefix (text before '-') of the namespace
 # field above.
-namePrefix: kwasm-operator-
+namePrefix: runtime-class-manager-
 
 # Labels to add to all resources and selectors.
 #labels:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -6,8 +6,8 @@ metadata:
     app.kubernetes.io/name: namespace
     app.kubernetes.io/instance: system
     app.kubernetes.io/component: manager
-    app.kubernetes.io/created-by: kwasm-operator
-    app.kubernetes.io/part-of: kwasm-operator
+    app.kubernetes.io/created-by: runtime-class-manager
+    app.kubernetes.io/part-of: runtime-class-manager
     app.kubernetes.io/managed-by: kustomize
   name: system
 ---
@@ -21,8 +21,8 @@ metadata:
     app.kubernetes.io/name: deployment
     app.kubernetes.io/instance: controller-manager
     app.kubernetes.io/component: manager
-    app.kubernetes.io/created-by: kwasm-operator
-    app.kubernetes.io/part-of: kwasm-operator
+    app.kubernetes.io/created-by: runtime-class-manager
+    app.kubernetes.io/part-of: runtime-class-manager
     app.kubernetes.io/managed-by: kustomize
 spec:
   selector:

--- a/config/prometheus/monitor.yaml
+++ b/config/prometheus/monitor.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/name: servicemonitor
     app.kubernetes.io/instance: controller-manager-metrics-monitor
     app.kubernetes.io/component: metrics
-    app.kubernetes.io/created-by: kwasm-operator
-    app.kubernetes.io/part-of: kwasm-operator
+    app.kubernetes.io/created-by: runtime-class-manager
+    app.kubernetes.io/part-of: runtime-class-manager
     app.kubernetes.io/managed-by: kustomize
   name: controller-manager-metrics-monitor
   namespace: system

--- a/config/rbac/auth_proxy_client_clusterrole.yaml
+++ b/config/rbac/auth_proxy_client_clusterrole.yaml
@@ -5,8 +5,8 @@ metadata:
     app.kubernetes.io/name: clusterrole
     app.kubernetes.io/instance: metrics-reader
     app.kubernetes.io/component: kube-rbac-proxy
-    app.kubernetes.io/created-by: kwasm-operator
-    app.kubernetes.io/part-of: kwasm-operator
+    app.kubernetes.io/created-by: runtime-class-manager
+    app.kubernetes.io/part-of: runtime-class-manager
     app.kubernetes.io/managed-by: kustomize
   name: metrics-reader
 rules:

--- a/config/rbac/auth_proxy_role.yaml
+++ b/config/rbac/auth_proxy_role.yaml
@@ -5,8 +5,8 @@ metadata:
     app.kubernetes.io/name: clusterrole
     app.kubernetes.io/instance: proxy-role
     app.kubernetes.io/component: kube-rbac-proxy
-    app.kubernetes.io/created-by: kwasm-operator
-    app.kubernetes.io/part-of: kwasm-operator
+    app.kubernetes.io/created-by: runtime-class-manager
+    app.kubernetes.io/part-of: runtime-class-manager
     app.kubernetes.io/managed-by: kustomize
   name: proxy-role
 rules:

--- a/config/rbac/auth_proxy_role_binding.yaml
+++ b/config/rbac/auth_proxy_role_binding.yaml
@@ -5,8 +5,8 @@ metadata:
     app.kubernetes.io/name: clusterrolebinding
     app.kubernetes.io/instance: proxy-rolebinding
     app.kubernetes.io/component: kube-rbac-proxy
-    app.kubernetes.io/created-by: kwasm-operator
-    app.kubernetes.io/part-of: kwasm-operator
+    app.kubernetes.io/created-by: runtime-class-manager
+    app.kubernetes.io/part-of: runtime-class-manager
     app.kubernetes.io/managed-by: kustomize
   name: proxy-rolebinding
 roleRef:

--- a/config/rbac/auth_proxy_service.yaml
+++ b/config/rbac/auth_proxy_service.yaml
@@ -6,8 +6,8 @@ metadata:
     app.kubernetes.io/name: service
     app.kubernetes.io/instance: controller-manager-metrics-service
     app.kubernetes.io/component: kube-rbac-proxy
-    app.kubernetes.io/created-by: kwasm-operator
-    app.kubernetes.io/part-of: kwasm-operator
+    app.kubernetes.io/created-by: runtime-class-manager
+    app.kubernetes.io/part-of: runtime-class-manager
     app.kubernetes.io/managed-by: kustomize
   name: controller-manager-metrics-service
   namespace: system

--- a/config/rbac/leader_election_role.yaml
+++ b/config/rbac/leader_election_role.yaml
@@ -6,8 +6,8 @@ metadata:
     app.kubernetes.io/name: role
     app.kubernetes.io/instance: leader-election-role
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: kwasm-operator
-    app.kubernetes.io/part-of: kwasm-operator
+    app.kubernetes.io/created-by: runtime-class-manager
+    app.kubernetes.io/part-of: runtime-class-manager
     app.kubernetes.io/managed-by: kustomize
   name: leader-election-role
 rules:

--- a/config/rbac/leader_election_role_binding.yaml
+++ b/config/rbac/leader_election_role_binding.yaml
@@ -5,8 +5,8 @@ metadata:
     app.kubernetes.io/name: rolebinding
     app.kubernetes.io/instance: leader-election-rolebinding
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: kwasm-operator
-    app.kubernetes.io/part-of: kwasm-operator
+    app.kubernetes.io/created-by: runtime-class-manager
+    app.kubernetes.io/part-of: runtime-class-manager
     app.kubernetes.io/managed-by: kustomize
   name: leader-election-rolebinding
 roleRef:

--- a/config/rbac/role_binding.yaml
+++ b/config/rbac/role_binding.yaml
@@ -5,8 +5,8 @@ metadata:
     app.kubernetes.io/name: clusterrolebinding
     app.kubernetes.io/instance: manager-rolebinding
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: kwasm-operator
-    app.kubernetes.io/part-of: kwasm-operator
+    app.kubernetes.io/created-by: runtime-class-manager
+    app.kubernetes.io/part-of: runtime-class-manager
     app.kubernetes.io/managed-by: kustomize
   name: manager-rolebinding
 roleRef:

--- a/config/rbac/service_account.yaml
+++ b/config/rbac/service_account.yaml
@@ -5,8 +5,8 @@ metadata:
     app.kubernetes.io/name: serviceaccount
     app.kubernetes.io/instance: controller-manager-sa
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: kwasm-operator
-    app.kubernetes.io/part-of: kwasm-operator
+    app.kubernetes.io/created-by: runtime-class-manager
+    app.kubernetes.io/part-of: runtime-class-manager
     app.kubernetes.io/managed-by: kustomize
   name: controller-manager
   namespace: system

--- a/config/rbac/shim_editor_role.yaml
+++ b/config/rbac/shim_editor_role.yaml
@@ -6,8 +6,8 @@ metadata:
     app.kubernetes.io/name: clusterrole
     app.kubernetes.io/instance: shim-editor-role
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: kwasm-operator
-    app.kubernetes.io/part-of: kwasm-operator
+    app.kubernetes.io/created-by: runtime-class-manager
+    app.kubernetes.io/part-of: runtime-class-manager
     app.kubernetes.io/managed-by: kustomize
   name: shim-editor-role
 rules:

--- a/config/rbac/shim_viewer_role.yaml
+++ b/config/rbac/shim_viewer_role.yaml
@@ -6,8 +6,8 @@ metadata:
     app.kubernetes.io/name: clusterrole
     app.kubernetes.io/instance: shim-viewer-role
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: kwasm-operator
-    app.kubernetes.io/part-of: kwasm-operator
+    app.kubernetes.io/created-by: runtime-class-manager
+    app.kubernetes.io/part-of: runtime-class-manager
     app.kubernetes.io/managed-by: kustomize
   name: shim-viewer-role
 rules:

--- a/config/samples/test_shim_lunatic.yaml
+++ b/config/samples/test_shim_lunatic.yaml
@@ -5,9 +5,9 @@ metadata:
   labels:
     app.kubernetes.io/name: lunatic-v1
     app.kubernetes.io/instance: lunatic-v1
-    app.kubernetes.io/part-of: kwasm-operator
+    app.kubernetes.io/part-of: runtime-class-manager
     app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/created-by: kwasm-operator
+    app.kubernetes.io/created-by: runtime-class-manager
 spec:
   nodeSelector:
     lunatic: "true"

--- a/config/samples/test_shim_slight.yaml
+++ b/config/samples/test_shim_slight.yaml
@@ -5,9 +5,9 @@ metadata:
   labels:
     app.kubernetes.io/name: slight-v1
     app.kubernetes.io/instance: slight-v1
-    app.kubernetes.io/part-of: kwasm-operator
+    app.kubernetes.io/part-of: runtime-class-manager
     app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/created-by: kwasm-operator
+    app.kubernetes.io/created-by: runtime-class-manager
 spec:
   nodeSelector:
     slight: "true"

--- a/config/samples/test_shim_spin.yaml
+++ b/config/samples/test_shim_spin.yaml
@@ -5,9 +5,9 @@ metadata:
   labels:
     app.kubernetes.io/name: spin-v2
     app.kubernetes.io/instance: spin-v2
-    app.kubernetes.io/part-of: kwasm-operator
+    app.kubernetes.io/part-of: runtime-class-manager
     app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/created-by: kwasm-operator
+    app.kubernetes.io/created-by: runtime-class-manager
 spec:
   nodeSelector:
     spin: "true"

--- a/config/samples/test_shim_wws.yaml
+++ b/config/samples/test_shim_wws.yaml
@@ -5,9 +5,9 @@ metadata:
   labels:
     app.kubernetes.io/name: wws-v1
     app.kubernetes.io/instance: wws-v1
-    app.kubernetes.io/part-of: kwasm-operator
+    app.kubernetes.io/part-of: runtime-class-manager
     app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/created-by: kwasm-operator
+    app.kubernetes.io/created-by: runtime-class-manager
 spec:
   nodeSelector:
     wws: "true"

--- a/tilt-settings.yaml.example
+++ b/tilt-settings.yaml.example
@@ -1,2 +1,2 @@
 # Replace with a development registry that offers pull & push access
-registry: ghcr.io/<your github handle>/kwasm-operator
+registry: ghcr.io/<your github handle>/runtime-class-manager


### PR DESCRIPTION
## Describe your changes

Replaces "kwasm-operator" with "runtime-class-manager"

(A few other spots relating to the forthcoming helm chart were updated in the [corresponding PR](https://github.com/spinkube/runtime-class-manager/pull/204); see https://github.com/spinkube/runtime-class-manager/pull/204/commits/37c49369bf8ddb689e8dc8ca0d79866eb9d5f05a and https://github.com/spinkube/runtime-class-manager/pull/204/commits/f5b00e6164ce79a6af1df77bab20485391b60ca0)

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- I tested the changes with the following distributions:
  - [ ] Kind
  - [ ] MiniKube
  - [ ] MicroK8s
  - [ ] Rancher RKE2
  - [ ] Azure AKS
  - [ ] GCP GKE (Ubuntu nodes)
  - [ ] AWS EKS (AmazonLinux2 nodes)
  - [ ] AWS EKS (Ubuntu nodes)
  - [ ] Digital Ocean Kubernetes