### PR TITLE
ci(.github): add helm chart smoketest workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,9 @@ permissions:
   checks: write
 
 jobs:
+  helm_install_smoke_test:
+    uses: ./.github/workflows/helm-chart-smoketest.yml
+
   unit_tests:
     name: Test
     runs-on: ubuntu-latest

--- a/.github/workflows/helm-chart-smoketest.yml
+++ b/.github/workflows/helm-chart-smoketest.yml
@@ -1,0 +1,118 @@
+name: Helm Chart Smoketest
+
+on:
+  workflow_call:
+
+env:
+  SHIM_SPIN_VERSION: v0.15.1
+
+jobs:
+  helm-install-smoke-test:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install helm
+        uses: Azure/setup-helm@v4
+        with:
+          version: v3.15.4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build RCM
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          load: true
+          tags: |
+            runtime-class-manager:chart-test
+
+      - name: Build node installer
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./images/installer/Dockerfile
+          platforms: linux/amd64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          load: true
+          tags: |
+            node-installer:chart-test
+
+      - name: Build shim downloader
+        uses: docker/build-push-action@v6
+        with:
+          context: ./images/downloader
+          file: ./images/downloader/Dockerfile
+          platforms: linux/amd64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          load: true
+          tags: |
+            shim-downloader:chart-test
+
+      - name: create kind cluster
+        uses: helm/kind-action@v1
+        with:
+          cluster_name: kind
+
+      - name: import images into kind cluster
+        run: |
+          kind load docker-image runtime-class-manager:chart-test
+          kind load docker-image node-installer:chart-test
+          kind load docker-image shim-downloader:chart-test
+
+      - name: helm install runtime-class-manager
+        run: |
+          helm install rcm \
+            --namespace rcm \
+            --create-namespace \
+            --debug \
+            --set image.repository=runtime-class-manager \
+            --set image.tag=chart-test \
+            --set rcm.nodeInstallerImage.repository=node-installer \
+            --set rcm.nodeInstallerImage.tag=chart-test \
+            --set rcm.shimDownloaderImage.repository=shim-downloader \
+            --set rcm.shimDownloaderImage.tag=chart-test \
+            deploy/helm
+
+      - name: apply Spin shim
+        run: |
+          # Ensure shim binary is compatible with runner arch
+          yq -i '.spec.fetchStrategy.anonHttp.location = "https://github.com/spinkube/containerd-shim-spin/releases/download/${{ env.SHIM_SPIN_VERSION }}/containerd-shim-spin-v2-linux-x86_64.tar.gz"' \
+            config/samples/test_shim_spin.yaml
+          kubectl apply -f config/samples/test_shim_spin.yaml
+
+      - name: label nodes
+        run: kubectl label node --all spin=true
+
+      - name: run Spin App
+        run: |
+          kubectl apply -f testdata/apps/spin-app.yaml
+          kubectl rollout status deployment wasm-spin --timeout 90s
+          kubectl get pods -A
+          kubectl port-forward svc/wasm-spin 8083:80 &
+          timeout 15s bash -c 'until curl -f -vvv http://localhost:8083/hello; do sleep 2; done'
+
+      - name: debug
+        if: failure()
+        run: |
+          kubectl get pods -A
+          kubectl describe shim spin-v2
+          kubectl describe runtimeclass wasmtime-spin-v2
+          kubectl describe -n rcm pod -l job-name=kind-control-plane-spin-v2-install || true
+          kubectl logs -n rcm -l app.kubernetes.io/name=runtime-class-manager || true
+          kubectl describe -n rcm pod -l app.kubernetes.io/name=runtime-class-manager || true
+          kubectl logs -l app=wasm-spin || true
+          kubectl describe pod -l app=wasm-spin || true
+
+      - name: Verify curl
+        run: curl localhost:8083/hello

--- a/testdata/apps/spin-app.yaml
+++ b/testdata/apps/spin-app.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: wasm-spin
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: wasm-spin
+  template:
+    metadata:
+      labels:
+        app: wasm-spin
+    spec:
+      runtimeClassName: wasmtime-spin-v2
+      containers:
+      - name: spin-hello
+        image: ghcr.io/spinkube/spin-operator/hello-world:20240909-145818-g30def7d
+        command: ["/"]
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: wasm-spin
+spec:
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 80
+  selector:
+    app: wasm-spin


### PR DESCRIPTION
## Describe your changes

Adds initial helm chart test automation using a KinD cluster.

Ref https://github.com/spinkube/runtime-class-manager/issues/48

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- I tested the changes with the following distributions:
  - [x] Kind
  - [ ] MiniKube
  - [ ] MicroK8s
  - [ ] Rancher RKE2
  - [ ] Azure AKS
  - [ ] GCP GKE (Ubuntu nodes)
  - [ ] AWS EKS (AmazonLinux2 nodes)
  - [ ] AWS EKS (Ubuntu nodes)
  - [ ] Digital Ocean Kubernetes