### PR TITLE
ci(release.yml): rm unused latest release step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,22 +50,6 @@ jobs:
         run: |
           echo TAG_NAME=$(echo ${{ github.ref_name }}) >> $GITHUB_ENV
 
-      - name: Get latest release tag
-        id: get_last_release_tag
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
-        with:
-          script: |
-            let release = await github.rest.repos.getLatestRelease({
-               owner: context.repo.owner,
-               repo: context.repo.repo,
-            });
-
-            if (release.status  === 200 ) {
-              core.setOutput('old_release_tag', release.data.tag_name)
-              return
-            }
-            core.setFailed("Cannot find latest release")
-
       - name: Get release ID from the release created by release drafter
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:


### PR DESCRIPTION
## Describe your changes

- Removes the step attempting to get the latest release

We'd need a first release for this to succeed (otherwise it fails with a 404).  If we're certain we'll want this step in the future and we'll use the output it provides, I'm happy to update this PR to just comment it out for now.

## Issue ticket number and link

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- I tested the changes with the following distributions:
  - [ ] Kind
  - [ ] MiniKube
  - [ ] MicroK8s
  - [ ] Rancher RKE2
  - [ ] Azure AKS
  - [ ] GCP GKE (Ubuntu nodes)
  - [ ] AWS EKS (AmazonLinux2 nodes)
  - [ ] AWS EKS (Ubuntu nodes)
  - [ ] Digital Ocean Kubernetes