### PR TITLE
Allow users to configure TTL for Installer Job

### DIFF
--- a/deploy/helm/templates/deployment.yaml
+++ b/deploy/helm/templates/deployment.yaml
@@ -43,6 +43,8 @@ spec:
             value: "{{ .Values.rcm.shimDownloaderImage.repository }}:{{ .Values.rcm.shimDownloaderImage.tag | default .Chart.AppVersion }}"
           - name: SHIM_NODE_INSTALLER_IMAGE
             value: "{{ .Values.rcm.nodeInstallerImage.repository }}:{{ .Values.rcm.nodeInstallerImage.tag | default .Chart.AppVersion }}"
+          - name: SHIM_NODE_INSTALLER_JOB_TTL
+            value: "{{ .Values.rcm.nodeInstallerJob.ttl | default 0 }}"
           ports:
             - name: http
               containerPort: {{ .Values.service.port }}

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -17,6 +17,8 @@ rcm:
   nodeInstallerImage:
     repository: "ghcr.io/spinkube/node-installer"
     tag: "latest"
+  nodeInstallerJob:
+    ttl: 0
 
 imagePullSecrets: []
 nameOverride: ""

--- a/internal/controller/shim_controller.go
+++ b/internal/controller/shim_controller.go
@@ -462,7 +462,7 @@ func (sr *ShimReconciler) createJobManifest(shim *rcmv1.Shim, node *corev1.Node,
 	}
 	// set ttl for the installer job only if specified by the user
 	if ttlStr := os.Getenv("SHIM_NODE_INSTALLER_JOB_TTL"); ttlStr != "" {
-		if ttl, err := strconv.Atoi(ttlStr); err == nil && ttl > 0 {
+		if ttl, err := strconv.ParseInt(ttlStr, 10, 32); err == nil && ttl > 0 {
 			job.Spec.TTLSecondsAfterFinished = ptr(int32(ttl))
 		}
 	}


### PR DESCRIPTION
## Describe your changes

With this PR, users can specify the `TTLSecondsAfterFinished` when deploying the runtime-class-manager chart by setting the `rcm.nodeInstallerJob.ttl` value.

If the value is not set by the user or `0` the controller will not set the corresponding property on Job spec.

closes #199

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- I tested the changes with the following distributions:
  - [ ] Kind
  - [ ] MiniKube
  - [ ] MicroK8s
  - [ ] Rancher RKE2
  - [ ] Azure AKS
  - [ ] GCP GKE (Ubuntu nodes)
  - [ ] AWS EKS (AmazonLinux2 nodes)
  - [ ] AWS EKS (Ubuntu nodes)
  - [ ] Digital Ocean Kubernetes